### PR TITLE
Bugfixes Titlepage \myFaculty spacing

### DIFF
--- a/frontbackmatter/Titlepage.tex
+++ b/frontbackmatter/Titlepage.tex
@@ -20,7 +20,7 @@
     \vspace{0.1cm}
     \huge \textbf{\myUni}\\
     \vspace{0.4cm}
-    \LARGE -- \myFaculty --
+    \LARGE --~\myFaculty~--
   \end{center}
 
   \vfill


### PR DESCRIPTION
There is a spacing error on the right side of the \myFaculty part of the Titlepage:
![grafik](https://user-images.githubusercontent.com/25035182/70643481-5e5fa580-1c41-11ea-854f-d8518f3e51b2.png)

This is how it will look like with this patch:
![grafik](https://user-images.githubusercontent.com/25035182/70643633-a4b50480-1c41-11ea-8860-d75aca151136.png)
