### PR TITLE
Dockerfiles: Use LABEL instead of MAINTAINER

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-MAINTAINER mbredel "https://github.com/mbredel"
+LABEL maintainer="mbredel https://github.com/mbredel"
 
 # Install packages for building the LaTeX template.
 RUN apt-get -qq update && apt-get install -y --no-install-recommends \

--- a/Dockerfile.travis
+++ b/Dockerfile.travis
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-MAINTAINER mbredel "https://github.com/mbredel"
+LABEL maintainer="mbredel https://github.com/mbredel"
 
 # Install packages for building the LaTeX template.
 RUN apt-get -qq update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
The `MAINTAINER` instruction is deprecated since Docker 1.13.0 and should not be used anymore.

Instead the more flexible `LABEL` instruction can be used

Documentation:

https://docs.docker.com/engine/deprecated/#maintainer-in-dockerfile

https://docs.docker.com/engine/reference/builder/#maintainer-deprecated