### PR TITLE
Make Bibliography sloppy

### DIFF
--- a/frontbackmatter/Bibliography.tex
+++ b/frontbackmatter/Bibliography.tex
@@ -12,4 +12,12 @@
   \addcontentsline{toc}{chapter}{\tocEntry{#1}}%
   \chapter*{#1}%
 }
+
+% allow Linebreaks in urls anywhere
+\setcounter{biburlnumpenalty}{100}
+\setcounter{biburlucpenalty}{100}
+\setcounter{biburllcpenalty}{100}
+% enable to long words to break anywhere by increasing the allowed whitespace between words.
+\sloppy
+
 \printbibliography[heading=bibintoc]


### PR DESCRIPTION
The Bibliography often contains long unbreakable segments (like URLs) which makes it look ugly.

This fix enables breaking long words even if the spacing will be more than normally allowed. This is acceptable for the bibliography to gain a more clean looking result.

Many fellow students used this recommended modification and were happy with it. That's the reason i think it should be merged in the original template. 

Comparison-Example (Edited)
![image](https://user-images.githubusercontent.com/17324992/146004939-6e0e9cc9-13a6-42fb-bcce-b8a227947953.png)

![image](https://user-images.githubusercontent.com/17324992/146005630-22d8a8fe-3ed1-4ab0-9d2f-23cb636bbbb3.png)
