### PR TITLE
Remove obsolete `abstractoff` option

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -33,7 +33,7 @@
     %\WarningFilter{scrreprt}{Activating an ugly workaround}
     \WarningFilter{titlesec}{Non standard sectioning command detected}
 \documentclass[ openright,titlepage,numbers=noenddot,headinclude,%twoside, %1headlines,% letterpaper a4paper
-                footinclude=true,cleardoublepage=empty,abstractoff, % <--- obsolete, remove (todo)
+                footinclude=true,cleardoublepage=empty,
                 BCOR=5mm,paper=a4,fontsize=11pt,%11pt,a4paper,%
                 ngerman,american,%lockflag%
                 ]{scrreprt}


### PR DESCRIPTION
Fixes warning:

> Class scrreprt Warning: You've used obsolete option `abstractoff'.
(scrreprt)              Usage of this option indicates an old document
(scrreprt)              and changes compatibility level using
(scrreprt)              `abstract=false,version=first,
(scrreprt)              enabledeprecatedfontcommands' that may result
(scrreprt)              in further warnings.
(scrreprt)              If you don't want this, you should simply
(scrreprt)              replace option `abstractoff' by `abstract=false'.

Basically you can replace 'abstractoff' by 'abstract=false'

But after reading the packages documentation, you can remove it already because false is the default

See german doc, page 74, 3.8 Zusammenfassung, Paragraph abstract=Ein-Aus-Wert
http://mirrors.ctan.org/macros/latex/contrib/koma-script/doc/scrguide.pdf

Package-Link; https://ctan.org/pkg/scrreprt