### PR TITLE
Improved the titles of acronyms and declaration pages

### DIFF
--- a/frontbackmatter/Acronyms.tex
+++ b/frontbackmatter/Acronyms.tex
@@ -7,7 +7,7 @@
 \refstepcounter{dummy}
 \pdfbookmark[0]{Abk\"{u}rzungsverzeichnis}{abkuerzungsverzeichnis}
 \markboth{\spacedlowsmallcaps{Abk\"{u}rzungsverzeichnis}}{\spacedlowsmallcaps{Abk\"{u}rzungsverzeichnis}}
-\chapter*{Abk\"{u}rzungsverzeichnis}
+\chapter*{\condENGLISH{Acronyms}{Abk\"{u}rzungsverzeichnis}}
 
 % Insert your acronyms here
 \begin{acronym}[UML]

--- a/frontbackmatter/Declaration.tex
+++ b/frontbackmatter/Declaration.tex
@@ -3,7 +3,7 @@
 %*******************************************************
 \refstepcounter{dummy}
 \pdfbookmark[0]{Declaration}{declaration}
-\chapter*{\condENGLISH{Declaration}{Erklärung}}
+\chapter*{Eigenständigkeitserklärung}
 \thispagestyle{empty}
 Ich versichere hiermit, dass ich die vorliegende Arbeit selbstständig verfasst und keine anderen als die im Literaturverzeichnis angegebenen Quellen benutzt habe.
 \medskip


### PR DESCRIPTION
These changes
- enable the english title for the acronyms page when english is selected as language
- remove the english title for declaration page which must always be in german